### PR TITLE
Fix horizontal scroll issue caused by pepemon walking outside of viewport

### DIFF
--- a/packages/app/src/views/Home/Home.tsx
+++ b/packages/app/src/views/Home/Home.tsx
@@ -46,7 +46,7 @@ const Home: React.FC<any> = () => {
 			</StyledSection>
 			
 			<LazyLoadComponent threshold={200}>
-				<StyledSection bgImage={coverblack} desktopStyle={{ color: theme.color.white, textAlign: 'center' }}>
+				<StyledSection bgImage={coverblack} mobileStyle={{ overflowX: 'hidden' }} desktopStyle={{ color: theme.color.white, textAlign: 'center' }}>
 					<ContentCentered style={{paddingTop: "7.5em"}}>
 						<Title as="h1" font={theme.font.neometric} size='xxl' color='inherit' weight={900} lineHeight={1.04}>
 							Start earning<br /> before ETH 2.0


### PR DESCRIPTION
This was the culprit:

<img width="401" alt="afbeelding" src="https://user-images.githubusercontent.com/8208970/175674217-a4465551-e090-4b1e-992e-3b2ed93b5043.png">

Issue should be solved by disabling horizontal scroll on that section on mobile.
